### PR TITLE
Update to the v1 of the xml crate (previously known as xml-rs)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raves_xmltree"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Andrew Chin <achin@eminence32.net>"]
 description = "Parse an XML file into a simple tree-like structure"
 repository = "https://github.com/raves-project/raves_xmltree"
@@ -11,7 +11,7 @@ categories = ["parsing", "data-structures"]
 edition = "2021"
 
 [dependencies]
-xml-rs = "0.8"
+xml = "1"
 indexmap = { version = "2", optional = true }
 
 [features]

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Add the following to your `Cargo.toml` file:
 
 ```toml
 [dependencies]
-xmltree = "0.11"
+xmltree = "0.12"
 ```
 
 ### Feature-flags
@@ -28,12 +28,16 @@ xmltree = "0.11"
 
 - `attribute-sorted` - change the data structure that stores attributes to one that uses sorted order. This changes the type definition.
 
-## Compatibility with xml-rs
+## Compatibility with xml crate
 
-This crate will export some types from the xml-rs crate. If your own crate also uses the xml-rs crate, but with a different version, the types may be incompatible. One way to solve this is to only use the exported types, but sometimes that is not always possible. In those cases you should use a version of xmltree that matches the version of xml-rs you are using:
+This crate will export some types from the [xml](https://crates.io/crates/xml) crate.  If your own crate also uses the xml
+crate, but with a different version, the types may be incompatible.  One way to solve this is to
+only use the exported types, but sometimes that is not always possible.  In those cases you should
+use a version of xmltree that matches the version of xml you are using:
 
-| xml-rs version | xmltree version |
-| -------------- | --------------- |
+| xml version    | xmltree version |
+|----------------|-----------------|
+| 1              | 0.12            |
 | 0.8            | 0.11            |
 | 0.7            | 0.8             |
 | 0.6            | 0.6             |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -242,6 +242,7 @@ fn build<B: Read>(reader: &mut EventReader<B>, mut elem: Element) -> Result<Elem
             Ok(XmlEvent::StartDocument { .. }) | Ok(XmlEvent::EndDocument) => {
                 return Err(ParseError::CannotParse)
             }
+            Ok(XmlEvent::Doctype { .. }) => (),
             Err(e) => return Err(ParseError::MalformedXml(e)),
         }
     }
@@ -316,6 +317,7 @@ impl Element {
                 }
                 Ok(XmlEvent::EndElement { .. }) => (),
                 Ok(XmlEvent::EndDocument) => return Ok(root_nodes),
+                Ok(XmlEvent::Doctype { .. }) => (),
                 Err(e) => return Err(ParseError::MalformedXml(e)),
             }
         }


### PR DESCRIPTION
A cherry-pick from upstream https://github.com/eminence/xmltree-rs/pull/55 to catch up to `0.12.0`

